### PR TITLE
Update Support for Pyramid>=2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         include:
           # ubuntu-latest[22.04] does not have: py27, py36
           - os: "ubuntu-20.04"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-latest"
+          - "ubuntu-22.04"
         python-version: 
           - "3.7"
           - "3.8"
@@ -24,10 +24,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        include:
-          # ubuntu-latest[22.04] does not have: py27, py36
-          - os: "ubuntu-20.04"
-            python-version: "3.6"
+          - "3.13"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,11 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/python/black
-    rev: 23.3.0
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
     hooks:
-    -   id: black
-
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ include CHANGES.txt
 include LICENSE.txt
 include README.md
 
-recursive-exclude * __pycache__ *.py[cod] .DS_Store
+prune */.mypy_cache
+recursive-exclude * __pycache__ *.py[cod] .DS_Store .mypy_cache

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 Build Status: ![Python package](https://github.com/jvanasco/pyramid_session_multi/workflows/Python%20package/badge.svg)
 
-Provides for making multiple ad-hoc binds of `ISession` compliant Sessions onto
+Provides a framework for making multiple ad-hoc binds of `ISession` compliant Sessions onto
 a `request.session_multi` namespace.
+
+In other words...
+
+Instead of having a single `request.session` configured, you can configure multiple Pyramid session handlers to use `request.session_multi["your_identifier"]`
 
 # Usage
 

--- a/examples/single_file_app.py
+++ b/examples/single_file_app.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 """
 Directions:
 
@@ -37,7 +35,7 @@ Note there are two set-cookie values:
     Set-Cookie: client_cookie=vMfpxvLwGD9OkGO1Wwek_jke_eohqLOg0fUfCrdJYr0DtTXth3r74CMvvn2chreEGGxokL7gLUyRexCcpEdcrIACSgRetF9HQdftF4EjDa59cQFVAmlkcQJLAXOHcQMu; Path=/; SameSite=Lax
     Set-Cookie: server_cookie=8ae9bf114ddd46d6d20cfe17345f5500f8218febgAJVQEQxNjk2aHZhV252ZDZmUS1mck9rYTUzdUlxcGxXODJtbVcxaDN4OWRUTzYwZ1BkamYyZm8wdE1lMVBqOUVWQU1xAS4=; Path=/; HttpOnly
     Vary: Cookie
-    
+
 Try sending in the values on the next request for the clientside cookie
 
     curl http://0.0.0.0:6543 -I -H "Cookie: client_cookie=vMfpxvLwGD9OkGO1Wwek_jke_eohqLOg0fUfCrdJYr0DtTXth3r74CMvvn2chreEGGxokL7gLUyRexCcpEdcrIACSgRetF9HQdftF4EjDa59cQFVAmlkcQJLAXOHcQMu"
@@ -80,17 +78,22 @@ Because of this, the server_side cookie will not change value unless the
 cookie receives an updated timeout value or an invalidation.
 """
 
-from waitress import serve
+# pypi
 from pyramid.config import Configurator
+from pyramid.request import Request
 from pyramid.response import Response
-
-import pyramid_session_multi
-import pyramid_session_redis
-
 from pyramid.session import SignedCookieSessionFactory
+import pyramid_session_redis
+from waitress import serve
+
+# local
+import pyramid_session_multi
 
 
-def func_invalid_logger(request, raised_exception):
+def func_invalid_logger(
+    request: Request,
+    raised_exception: Exception,
+):
     """called by func_invalid_logger"""
     print("func_invalid_logger")
     print(request, raised_exception)
@@ -106,7 +109,7 @@ factory_serverside = pyramid_session_redis.session_factory_from_settings(
 )
 
 
-def hello_world(request):
+def hello_world(request: Request) -> Response:
     print("Incoming request")
     if "id" not in request.session_multi["clientside"]:
         request.session_multi["clientside"]["id"] = 0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,6 @@
+[mypy]
+check_untyped_defs = True
+
 [mypy-pyramid.*]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py37']

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,10 @@ import_order_style = appnexus
 
 #  E501 line too long (81 > 79 characters)
 per-file-ignores:
+    build/*: *
+    examples/*: E501
     src/pyramid_session_multi/__init__.py: E501
     src/pyramid_session_multi/debugtoolbar/panels/session_multi.py: E501
+    tests/*: E501
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """pyramid_session_multi installation script.
 """
+
 import os
 import re  # store version in the init.py
 
@@ -9,18 +10,18 @@ from setuptools import setup
 
 HERE = os.path.dirname(__file__)
 
-long_description = (
-    description
-) = "Provides a framwork for creating multiple adhoc session binds in Pyramid."
+long_description = description = (
+    "Provides a framwork for creating multiple adhoc session binds in Pyramid."
+)
 with open(os.path.join(HERE, "README.md")) as r_file:
     long_description = r_file.read()
 
 with open(os.path.join(HERE, "src", "pyramid_session_multi", "__init__.py")) as v_file:
-    VERSION = re.compile(r'.*__VERSION__ = "(.*?)"', re.S).match(v_file.read()).group(1)
+    VERSION = re.compile(r'.*__VERSION__ = "(.*?)"', re.S).match(v_file.read()).group(1)  # type: ignore[union-attr]
 
 # pyramid 1.5 == SignedCookieSessionFactory
 requires = [
-    "pyramid>=1.5",
+    "pyramid>=2",
     "zope.interface",  # installed by pyramid
 ]
 tests_require = [
@@ -39,7 +40,6 @@ setup(
         "Intended Audience :: Developers",
         "Framework :: Pyramid",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "Framework :: Pyramid",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
     ],
     keywords="pyramid session web",
     author="Jonathan Vanasco",

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,12 @@ setup(
         where="src",
     ),
     package_dir={"": "src"},
-    package_data={"pyramid_session_multi": ["py.typed"]},
-    include_package_data=True,
+    package_data={
+        "": [
+            "py.typed",
+            "debugtoolbar/panels/templates/*",
+        ],
+    },
     zip_safe=False,
     install_requires=requires,
     tests_require=requires,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 """pyramid_session_multi installation script.
 """
 import os
+import re  # store version in the init.py
 
-from setuptools import setup
 from setuptools import find_packages
+from setuptools import setup
 
-# store version in the init.py
-import re
 
 HERE = os.path.dirname(__file__)
 
@@ -53,6 +52,7 @@ setup(
         where="src",
     ),
     package_dir={"": "src"},
+    package_data={"pyramid_session_multi": ["py.typed"]},
     include_package_data=True,
     zip_safe=False,
     install_requires=requires,

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ with open(os.path.join(HERE, "README.md")) as r_file:
 with open(os.path.join(HERE, "src", "pyramid_session_multi", "__init__.py")) as v_file:
     VERSION = re.compile(r'.*__VERSION__ = "(.*?)"', re.S).match(v_file.read()).group(1)  # type: ignore[union-attr]
 
-# pyramid 1.5 == SignedCookieSessionFactory
 requires = [
     "pyramid>=2",
+    "typing_extensions",
     "zope.interface",  # installed by pyramid
 ]
 tests_require = [

--- a/src/pyramid_session_multi/__init__.py
+++ b/src/pyramid_session_multi/__init__.py
@@ -120,7 +120,10 @@ class SessionMultiManagerConfig(object):
     It is used to create new managers on each request.
     """
 
-    def __init__(self, config: "Configurator"):
+    def __init__(
+        self,
+        config: "Configurator",
+    ):
         self._session_factories: Dict[str, Callable] = {}
         self._discriminators: Dict[str, Callable] = {}
         self._cookienames: Dict[str, str] = {}
@@ -209,7 +212,10 @@ class SessionMultiManager(dict):
     mountpoints as needed.
     """
 
-    def __init__(self, request: "Request"):
+    def __init__(
+        self,
+        request: "Request",
+    ):
         self.request = request
         manager_config = request.registry.queryUtility(ISessionMultiManagerConfig)
         if manager_config is None:

--- a/src/pyramid_session_multi/__init__.py
+++ b/src/pyramid_session_multi/__init__.py
@@ -17,7 +17,6 @@ from zope.interface import Attribute
 from zope.interface import implementer
 from zope.interface import Interface
 
-# typing
 if TYPE_CHECKING:
     from pyramid.config import Configurator
     from pyramid.request import Request
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
 # ==============================================================================
 
 
-__VERSION__ = "0.4.0dev"
+__VERSION__ = "0.4.0"
 
 
 # ------------------------------------------------------------------------------
@@ -87,29 +86,33 @@ class ISessionMultiManagerConfig(Interface):
         """dict of namespaces to cookienames""" """:returns: dict"""
     )
 
-    def has_namespace(self, namespace: str):
+    def has_namespace(self, namespace: str) -> bool:  # type: ignore[empty-body]
         """
         is this a valid namespace/session?
         :returns: bool
         """
+        ...
 
-    def get_namespace_config(self, namespace: str):
+    def get_namespace_config(self, namespace: str) -> Optional[Callable]:
         """
         is this a valid namespace/session?
         :returns: a session factory or None
         """
+        ...
 
-    def get_namespace_cookiename(self, namespace: str):
+    def get_namespace_cookiename(self, namespace: str) -> Optional[str]:
         """
         get the namespace cookiename
         :returns: str or None
         """
+        ...
 
-    def get_namespace_discriminator(self, namespace: str):
+    def get_namespace_discriminator(self, namespace: str) -> Optional[Callable]:
         """
         get the namespace discriminator
         :returns: str or None
         """
+        ...
 
 
 @implementer(ISessionMultiManagerConfig)

--- a/src/pyramid_session_multi/debugtoolbar/__init__.py
+++ b/src/pyramid_session_multi/debugtoolbar/__init__.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 # local
 from .panels.session_multi import SessionMultiDebugPanel
 
-# typing
 if TYPE_CHECKING:
     from pyramid.config import Configurator  # type: ignore[import]
 

--- a/src/pyramid_session_multi/debugtoolbar/panels/session_multi.py
+++ b/src/pyramid_session_multi/debugtoolbar/panels/session_multi.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import TYPE_CHECKING
 
@@ -16,8 +17,10 @@ from ... import ISessionMultiManagerConfig
 
 # typing
 if TYPE_CHECKING:
+    from pyramid.interfaces import ISession
     from pyramid.request import Request  # type: ignore[import]
     from pyramid.response import Response  # type: ignore[import]
+    from ... import SessionMultiManager
 
 # ==============================================================================
 
@@ -74,10 +77,14 @@ class SessionMultiDebugPanel(DebugPanel):
         """
         return True
 
-    def __init__(self, request: "Request"):
-        """
-        Initial setup of the `data` payload.
-        """
+    def __init__(
+        self,
+        request: "Request",
+    ):
+        # we need this for processing in the response phase
+        self._request = request
+
+        # Initial setup of the `data` payload.
         data: Dict[str, Any] = {
             "configuration": None,
             "is_active": None,  # not known on `.__init__`
@@ -92,8 +99,6 @@ class SessionMultiDebugPanel(DebugPanel):
         }
         self.data = data
 
-        # we need this for processing in the response phase
-        self._request = request
         # try to stash the configuration info
         try:
             config = request.registry.getUtility(ISessionMultiManagerConfig)
@@ -130,7 +135,10 @@ class SessionMultiDebugPanel(DebugPanel):
             # the `ISessionFactory` is not configured
             pass
 
-    def wrap_handler(self, handler: Callable) -> Callable:
+    def wrap_handler(
+        self,
+        handler: Callable,
+    ) -> Callable:
         """
         ``wrap_handler`` allows us to monitor the entire lifecycle of
         the  ``Request``.
@@ -149,7 +157,10 @@ class SessionMultiDebugPanel(DebugPanel):
         """
         data = self.data
 
-        def _process_namespace(_namespace: str, _session):
+        def _process_namespace(
+            _namespace: str,
+            _session: Optional["ISession"],
+        ):
             # helper function
             # a discriminator could return None for the session
             if _session is not None:
@@ -158,18 +169,24 @@ class SessionMultiDebugPanel(DebugPanel):
                     data["session_data"][_namespace]["keys"].add(k)
 
         # define a wrapper for this session
-        def new_wrapper_a(_namespace: str, _session):
+        def new_wrapper_a(
+            _namespace: str,
+            _session: "ISession",
+        ) -> Callable:
             if _session is None:
                 data["session_accessed"][_namespace]["discriminator_fail"] = True
 
-            def session_wrapper():
+            def session_wrapper() -> "ISession":
                 data["session_accessed"][_namespace]["main"] = True
                 return _session
 
             return session_wrapper
 
-        def new_wrapper_b(_namespace: str):
-            def session_wrapper():
+        def new_wrapper_b(
+            session_multi: SessionMultiManager,
+            _namespace: str,
+        ) -> Callable:
+            def session_wrapper() -> "ISession":
                 # get the session
                 _session = session_multi._discriminated_session(_namespace)
 
@@ -233,14 +250,17 @@ class SessionMultiDebugPanel(DebugPanel):
 
                 else:
                     # generate a new wrapper
-                    session_wrapper = new_wrapper_b(namespace)
+                    session_wrapper = new_wrapper_b(session_multi, namespace)
 
                     # Replace the existing ``ISession`` interface with our wrapper.
                     dict.__setitem__(session_multi, namespace, session_wrapper)
 
         return handler
 
-    def process_response(self, response: "Response") -> None:
+    def process_response(
+        self,
+        response: "Response",
+    ) -> None:
         """
         ``Response`` | "egress"
 
@@ -255,7 +275,10 @@ class SessionMultiDebugPanel(DebugPanel):
         data = self.data
         session_multi = None
 
-        def _process_namespace(_namespace, _session):
+        def _process_namespace(
+            _namespace: str,
+            _session: "ISession",
+        ):
             # helper function
             # a discriminator could return None for the session
             if _session is not None:

--- a/src/pyramid_session_multi/debugtoolbar/panels/session_multi.py
+++ b/src/pyramid_session_multi/debugtoolbar/panels/session_multi.py
@@ -15,11 +15,11 @@ import zope.interface.interfaces  # type: ignore[import]
 # local
 from ... import ISessionMultiManagerConfig
 
-# typing
 if TYPE_CHECKING:
     from pyramid.interfaces import ISession
     from pyramid.request import Request  # type: ignore[import]
     from pyramid.response import Response  # type: ignore[import]
+
     from ... import SessionMultiManager
 
 # ==============================================================================
@@ -109,15 +109,15 @@ class SessionMultiDebugPanel(DebugPanel):
                 "namespaces": {},
             }
             for namespace in config.namespaces:
-                data["configuration"]["cookies"][
-                    namespace
-                ] = config.get_namespace_cookiename(namespace)
-                data["configuration"]["discriminators"][
-                    namespace
-                ] = config.get_namespace_discriminator(namespace)
-                data["configuration"]["namespaces"][
-                    namespace
-                ] = config.get_namespace_config(namespace)
+                data["configuration"]["cookies"][namespace] = (
+                    config.get_namespace_cookiename(namespace)
+                )
+                data["configuration"]["discriminators"][namespace] = (
+                    config.get_namespace_discriminator(namespace)
+                )
+                data["configuration"]["namespaces"][namespace] = (
+                    config.get_namespace_config(namespace)
+                )
                 data["session_accessed"][namespace] = {
                     "pre": None,  # pre-processing (toolbar)
                     "panel_setup": None,  # during the panel setup?
@@ -183,7 +183,7 @@ class SessionMultiDebugPanel(DebugPanel):
             return session_wrapper
 
         def new_wrapper_b(
-            session_multi: SessionMultiManager,
+            session_multi: "SessionMultiManager",
             _namespace: str,
         ) -> Callable:
             def session_wrapper() -> "ISession":

--- a/tests/_serializers.py
+++ b/tests/_serializers.py
@@ -1,0 +1,82 @@
+# stdlib
+import datetime
+import json
+import re
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+# pyramid
+
+# ==============================================================================
+
+
+RE_value_datetime_1 = re.compile(
+    r"^__datetime__\|(\d){4}-(\d){2}-(\d){2}T(\d){2}:(\d){2}:(\d){2}$"
+)
+
+
+class JsonEncoder_Datetime(json.JSONEncoder):
+    """Extends JSONEncoder for datetime type."""
+
+    def encode_datetime(self, dt: datetime.datetime) -> str:
+        """Serialize the given datetime.datetime object to a JSON string."""
+        # Default is ISO 8601 compatible (standard notation).
+        # Don't use strftime because that can't handle dates before 1900.
+        return "__datetime__|%04d-%02d-%02dT%02d:%02d:%02d" % (
+            dt.year,
+            dt.month,
+            dt.day,
+            dt.hour,
+            dt.minute,
+            dt.second,
+        )
+
+    def default(self, o: Any):
+        # We MUST check for a datetime.datetime instance before datetime.date.
+        # datetime.datetime is a subclass of datetime.date, and therefore
+        # instances of it are also instances of datetime.date.
+        if isinstance(o, datetime.datetime):
+            return self.encode_datetime(o)
+        else:
+            return json.JSONEncoder.default(self, o)
+
+
+def decoder_pair_hook(payload: List[Tuple[Any, Any]]) -> Dict:
+    """custom decoding of data strutures."""
+    rval: Dict = {}
+    for k, v in payload:
+        rval[k] = v
+        if isinstance(v, str):
+            if RE_value_datetime_1.match(v):
+                rval[k] = datetime.datetime.strptime(
+                    v.split("|")[1], "%Y-%m-%dT%H:%M:%S"
+                )
+    return rval
+
+
+def py2json(payload: Any) -> str:
+    return json.dumps(
+        payload, cls=JsonEncoder_Datetime, separators=(",", ":"), sort_keys=True
+    )
+
+
+def json2py(payload: str) -> Any:
+    return json.loads(payload, object_pairs_hook=decoder_pair_hook)
+
+
+class JSONSerializerWithDatetime(object):
+
+    def dumps(self, appstruct: Any) -> bytes:
+        """
+        Accept a Python object and return bytes.
+        """
+        return py2json(appstruct).encode()
+
+    def loads(self, bstruct: Union[bytes, str]) -> Any:
+        """Accept bytes and return a Python object."""
+        if isinstance(bstruct, bytes):
+            return json2py(bstruct.decode())
+        return json2py(bstruct)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -7,6 +7,8 @@ from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.session import SignedCookieSessionFactory
 
+# local
+from ._serializers import JSONSerializerWithDatetime
 
 # ==============================================================================
 
@@ -40,3 +42,8 @@ session_factory_1_duplicate = SignedCookieSessionFactory(
 )
 session_factory_2 = SignedCookieSessionFactory("secret2", cookie_name="session2")
 session_factory_3 = SignedCookieSessionFactory("secret3", cookie_name="session3")
+
+_JSON_SERIALIZER = JSONSerializerWithDatetime()
+session_factory_datetime = SignedCookieSessionFactory(
+    "secret3", cookie_name="sessionDatetime", serializer=_JSON_SERIALIZER
+)

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,8 +1,9 @@
 # stdlib
 import re
-import sys
+from typing import Literal
 
 # pyramid
+from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.session import SignedCookieSessionFactory
 
@@ -10,28 +11,22 @@ from pyramid.session import SignedCookieSessionFactory
 # ==============================================================================
 
 
-PY3 = sys.version_info[0] == 3
-
-
-# ------------------------------------------------------------------------------
-
-
-def discriminator_False(request):
+def discriminator_False(request: Request) -> Literal[False]:
     return False
 
 
-def discriminator_True(request):
+def discriminator_True(request: Request) -> Literal[True]:
     return True
 
 
-def ok_response_factory():
+def ok_response_factory() -> Response:
     return Response(
         "<html><head></head><body>OK</body></html>",
         content_type="text/html",
     )
 
 
-def empty_view(request):
+def empty_view(request: Request) -> Response:
     return ok_response_factory()
 
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,11 +1,11 @@
 # stdlib
 import re
-from typing import Literal
 
-# pyramid
+# pypi
 from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.session import SignedCookieSessionFactory
+from typing_extensions import Literal
 
 # local
 from ._serializers import JSONSerializerWithDatetime

--- a/tests/bench_serializers.py
+++ b/tests/bench_serializers.py
@@ -1,0 +1,201 @@
+"""
+This is not a test file, but used to determine performance between serializers
+"""
+
+# stdlib
+import datetime
+import json
+import re
+import timeit
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+# pypi
+from typing_extensions import TypedDict
+
+# ==============================================================================
+
+#
+# Encoder 1
+#
+# Datetime is encoded into an ISO 8601 compatible string
+#
+DATETIME_1__RE = re.compile(
+    r"^__datetime__\|(\d){4}-(\d){2}-(\d){2}T(\d){2}:(\d){2}:(\d){2}$"
+)
+
+
+class DATETIME_1__JsonEncoder(json.JSONEncoder):
+    """Extends JSONEncoder for datetime type."""
+
+    def encode_datetime(self, dt: datetime.datetime) -> str:
+        """Serialize the given datetime.datetime object to a JSON string."""
+        # Default is ISO 8601 compatible (standard notation).
+        # Don't use strftime because that can't handle dates before 1900.
+        return "__datetime__|%04d-%02d-%02dT%02d:%02d:%02d" % (
+            dt.year,
+            dt.month,
+            dt.day,
+            dt.hour,
+            dt.minute,
+            dt.second,
+        )
+
+    def default(self, o: Any):
+        # We MUST check for a datetime.datetime instance before datetime.date.
+        # datetime.datetime is a subclass of datetime.date, and therefore
+        # instances of it are also instances of datetime.date.
+        if isinstance(o, datetime.datetime):
+            return self.encode_datetime(o)
+        else:
+            return json.JSONEncoder.default(self, o)
+
+
+def DATETIME_1__JsonDecoder(payload: List[Tuple[Any, Any]]) -> Dict:
+    """custom decoding of data strutures."""
+    rval: Dict = {}
+    for k, v in payload:
+        rval[k] = v
+        if isinstance(v, str):
+            if DATETIME_1__RE.match(v):
+                rval[k] = datetime.datetime.strptime(
+                    v.split("|")[1], "%Y-%m-%dT%H:%M:%S"
+                )
+    return rval
+
+
+def DATETIME_1__py2json(payload: Any) -> str:
+    return json.dumps(
+        payload, cls=DATETIME_1__JsonEncoder, separators=(",", ":"), sort_keys=True
+    )
+
+
+def DATETIME_1__json2py(payload: str) -> Any:
+    return json.loads(payload, object_pairs_hook=DATETIME_1__JsonDecoder)
+
+
+class DATETIME_1__JSONSerializer(object):
+
+    def dumps(self, appstruct: Any) -> bytes:
+        """
+        Accept a Python object and return bytes.
+        """
+        return DATETIME_1__py2json(appstruct).encode()
+
+    def loads(self, bstruct: Union[bytes, str]) -> Any:
+        """Accept bytes and return a Python object."""
+        if isinstance(bstruct, bytes):
+            return DATETIME_1__json2py(bstruct.decode())
+        return DATETIME_1__json2py(bstruct)
+
+
+#
+# Encoder 2
+#
+# Datetime is encoded into an Epoch
+#
+DATETIME_2__RE = re.compile(r"^__datetime__\|(\d+)$")
+
+
+class DATETIME_2__JsonEncoder(json.JSONEncoder):
+    """Extends JSONEncoder for datetime type."""
+
+    def encode_datetime(self, dt: datetime.datetime) -> str:
+        """Serialize the given datetime.datetime object to a JSON string."""
+        # Default is ISO 8601 compatible (standard notation).
+        return "__datetime__|%d" % dt.timestamp()
+
+    def default(self, o: Any):
+        # We MUST check for a datetime.datetime instance before datetime.date.
+        # datetime.datetime is a subclass of datetime.date, and therefore
+        # instances of it are also instances of datetime.date.
+        if isinstance(o, datetime.datetime):
+            return self.encode_datetime(o)
+        else:
+            return json.JSONEncoder.default(self, o)
+
+
+def DATETIME_2__JsonDecoder(payload: List[Tuple[Any, Any]]) -> Dict:
+    """custom decoding of data strutures."""
+    rval: Dict = {}
+    for k, v in payload:
+        rval[k] = v
+        if isinstance(v, str):
+            if DATETIME_2__RE.match(v):
+                rval[k] = datetime.datetime.fromtimestamp(int(v.split("|")[1]))
+    return rval
+
+
+def DATETIME_2__py2json(payload: Any) -> str:
+    return json.dumps(
+        payload, cls=DATETIME_2__JsonEncoder, separators=(",", ":"), sort_keys=True
+    )
+
+
+def DATETIME_2__json2py(payload: str) -> Any:
+    return json.loads(payload, object_pairs_hook=DATETIME_2__JsonDecoder)
+
+
+class DATETIME_2__JSONSerializer(object):
+
+    def dumps(self, appstruct: Any) -> bytes:
+        """
+        Accept a Python object and return bytes.
+        """
+        return DATETIME_2__py2json(appstruct).encode()
+
+    def loads(self, bstruct: Union[bytes, str]) -> Any:
+        """Accept bytes and return a Python object."""
+        if isinstance(bstruct, bytes):
+            return DATETIME_1__json2py(bstruct.decode())
+        return DATETIME_1__json2py(bstruct)
+
+
+#
+# Run the tests
+#
+class TYPE_ENCODABLE(TypedDict):
+    version: int
+    name: str
+    datetime: datetime.datetime
+
+
+_DATETIME_1__JSONSerializer = DATETIME_1__JSONSerializer()
+_DATETIME_2__JSONSerializer = DATETIME_2__JSONSerializer()
+
+
+def DATETIME_1_RoundTrip(audit: bool = False):
+    payload: TYPE_ENCODABLE = {
+        "version": 1,
+        "name": "DATETIME_1",
+        "datetime": datetime.datetime.utcnow(),
+    }
+    _encoded = _DATETIME_1__JSONSerializer.dumps(payload)
+    _decoded = _DATETIME_1__JSONSerializer.loads(_encoded)
+    if audit:
+        assert payload["datetime"].replace(microsecond=0) == _decoded["datetime"]
+
+
+def DATETIME_2_RoundTrip(audit: bool = False):
+    payload: TYPE_ENCODABLE = {
+        "version": 1,
+        "name": "DATETIME_2",
+        "datetime": datetime.datetime.utcnow(),
+    }
+    _encoded = _DATETIME_2__JSONSerializer.dumps(payload)
+    _decoded = _DATETIME_2__JSONSerializer.loads(_encoded)
+    if audit:
+        assert payload["datetime"].replace(microsecond=0) == _decoded["datetime"]
+
+
+DATETIME_1_RoundTrip(audit=True)
+DATETIME_2_RoundTrip(audit=True)
+
+execution_time_1 = timeit.timeit(stmt=DATETIME_1_RoundTrip, number=10000)
+execution_time_2 = timeit.timeit(stmt=DATETIME_2_RoundTrip, number=10000)
+
+print(execution_time_1)
+print(execution_time_2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,12 @@
 # stdlib
 import unittest
 
-# pyramid
+# pypi
 from pyramid import testing
 from pyramid.exceptions import ConfigurationError
 
 # package
 from pyramid_session_multi import register_session_factory
-
-# local
 from ._utils import session_factory_1
 from ._utils import session_factory_1_duplicate
 from ._utils import session_factory_2
@@ -22,7 +20,7 @@ class Test_NotIncluded(unittest.TestCase):
     def setUp(self):
         request = testing.DummyRequest()
         self.config = config = testing.setUp(request=request)
-        self.settings = settings = config.registry.settings
+        self.settings = config.registry.settings
 
     def tearDown(self):
         testing.tearDown()
@@ -42,7 +40,7 @@ class Test_Included(unittest.TestCase):
         request = testing.DummyRequest()
         self.config = config = testing.setUp(request=request)
         config.include("pyramid_session_multi")
-        self.settings = settings = config.registry.settings
+        self.settings = config.registry.settings
 
     def tearDown(self):
         testing.tearDown()

--- a/tests/test_debugtoolbar_panel.py
+++ b/tests/test_debugtoolbar_panel.py
@@ -1,10 +1,12 @@
 # stdlib
+import datetime
 import random
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import TYPE_CHECKING
 import unittest
 
@@ -24,9 +26,11 @@ from ._utils import re_toolbar_link
 from ._utils import session_factory_1
 from ._utils import session_factory_2
 from ._utils import session_factory_3
+from ._utils import session_factory_datetime
 
 if TYPE_CHECKING:
     from pyramid.config import Configurator
+    from pyramid.response import Response
 
 # ==============================================================================
 
@@ -47,6 +51,7 @@ class SessionConfigMixin(object):
         "session_a": session_factory_1,
         "session_b": session_factory_2,
         "session_c": session_factory_3,
+        "session_datetime": session_factory_datetime,
     }
 
     # class setup; dict of session namespace to discriminator
@@ -54,6 +59,7 @@ class SessionConfigMixin(object):
         "session_a": discriminator_True,  # pass
         "session_b": discriminator_True,  # pass
         "session_c": discriminator_False,  # fail
+        "session_datetime": discriminator_True,  # pass
     }
 
     # set within `.setup`; pyramid config object; `testing.setUp()`
@@ -87,7 +93,7 @@ class _TestPanelConfiguration(unittest.TestCase, SessionConfigMixin):
 
     """
 
-    config: Configurator
+    config: "Configurator"
     app: Any
     re_toolbar_link = re_toolbar_link
 
@@ -168,11 +174,11 @@ class TestPanelConfiguration_Configured(_TestPanelConfiguration):
 
 
 class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
-    config: Configurator
+    config: "Configurator"
     app: Any
     re_toolbar_link = re_toolbar_link
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         """
         This function should define a Pyramid view.
         * (potentially) invoke ``ISession``
@@ -180,7 +186,15 @@ class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
         """
         raise NotImplementedError()
 
-    def _session_view_two(self, context, request):
+    def _session_view_two(self, context, request: "Request"):
+        """
+        This function should define a Pyramid view.
+        * (potentially) invoke ``ISession``
+        * return a ``Response``
+        """
+        raise NotImplementedError()
+
+    def _session_view_datetime(self, context, request: "Request"):
         """
         This function should define a Pyramid view.
         * (potentially) invoke ``ISession``
@@ -197,8 +211,10 @@ class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
         self.configure_sessions()
         config.add_route("session_view", "/session-view")
         config.add_route("session_view_two", "/session-view-two")
+        config.add_route("session_view_datetime", "/session-view-datetime")
         config.add_view(self._session_view, route_name="session_view")
         config.add_view(self._session_view_two, route_name="session_view_two")
+        config.add_view(self._session_view_datetime, route_name="session_view_datetime")
         # make the app
         self.settings = config.registry.settings
         self.app = config.make_wsgi_app()
@@ -206,7 +222,9 @@ class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
     def tearDown(self):
         testing.tearDown()
 
-    def _makeOne(self, is_active=None, sessions_invalid=None):
+    def _makeOne(
+        self, is_active=None, sessions_invalid=None
+    ) -> Tuple["Response", "Response"]:
         """
         Makes a request to the main application
         * which invokes `self._session_view`
@@ -252,7 +270,9 @@ class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
 
         return (resp_app, resp_toolbar)
 
-    def _makeAnother(self, resp_app, is_active=None):
+    def _makeTwo(
+        self, resp_app: "Response", is_active=None
+    ) -> Tuple["Response", "Response"]:
         """
         Makes a second request to the main application
         * which invokes ``self._session_view_two``
@@ -298,9 +318,66 @@ class _TestDebugtoolbarPanel(unittest.TestCase, SessionConfigMixin):
 
         return (resp_app2, resp_toolbar)
 
+    def _makeDatetime(
+        self,
+        resp_app: Optional["Response"] = None,
+        is_active=None,
+        sessions_invalid=None,
+    ) -> Tuple["Response", "Response"]:
+        """
+        Makes a request to the main application
+        * which invokes ``self._session_view_datetime``
+        * Make a request to the toolbar
+        * return the toolbar ``Response``
+
+        :param is_active:
+            Default ``None``
+            If ``True``, a ``pdbt_active`` cookie will be sent to activate
+            additional features in the "Session" panel.
+        :param sessions_invalid: iterable of invalid namespaces to create the
+            view with
+        """
+        # make a secondary request
+        req1 = Request.blank("/session-view-datetime")
+        req1.remote_addr = "127.0.0.1"
+        _cookies = []
+        if is_active:
+            _cookies.append("pdtb_active=session_multi")
+        if resp_app:
+            if "Set-Cookie" in resp_app.headers:
+                for _set_cookie_header in resp_app.headers.getall("Set-Cookie"):
+                    _cks = parse_cookie(_set_cookie_header)
+                    for _ck in _cks:
+                        _cookies.append("%s=%s" % (_ck[0].decode(), _ck[1].decode()))
+        if sessions_invalid:
+            manager_config = self.app.registry.queryUtility(ISessionMultiManagerConfig)
+            for ns, ckname in manager_config.namespaces_to_cookienames.items():
+                if ns in sessions_invalid:
+                    # create an invalid cookie
+                    _cookies.append("%s=123123123123" % ns)
+        if _cookies:
+            _cookies_str = "; ".join(_cookies)
+            req1.headers["Cookie"] = _cookies_str
+        resp_app = req1.get_response(self.app)
+        self.assertEqual(resp_app.status_code, 200)
+        self.assertIn("http://localhost/_debug_toolbar/", resp_app.text)
+
+        # check the toolbar
+        links = self.re_toolbar_link.findall(resp_app.text)
+        self.assertIsNotNone(links)
+        self.assertIsInstance(links, list)
+        self.assertEqual(len(links), 1)
+        toolbar_link = links[0]
+
+        req2 = Request.blank(toolbar_link)
+        req2.remote_addr = "127.0.0.1"
+        resp_toolbar = req2.get_response(self.app)
+
+        return (resp_app, resp_toolbar)
+
     def _check_rendered__panel(
         self,
-        resp,
+        resp: "Response",
         is_configured=None,
         sessions_accessed=None,
         sessions_discriminator_fail=None,
@@ -362,7 +439,7 @@ class TestNoSessionConfigured(_TestDebugtoolbarPanel):
 
     enable_sessions = False
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         return ok_response_factory()
 
     def test_panel(self):
@@ -380,7 +457,7 @@ class TestSessionConfiguredNoAccess(_TestDebugtoolbarPanel):
     * no "Session" data is accessed
     """
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         return ok_response_factory()
 
     def test_panel(self):
@@ -405,12 +482,18 @@ class TestSimpleSession(_TestDebugtoolbarPanel):
     * "Session" data is accessed
     """
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         request.session_multi["session_a"]["foo"] = "bar"
         return ok_response_factory()
 
-    def _session_view_two(self, context, request):
+    def _session_view_two(self, context, request: "Request"):
         request.session_multi["session_a"]["foo"] = "barbar"
+        return ok_response_factory()
+
+    def _session_view_datetime(self, context, request: "Request"):
+        request.session_multi["session_datetime"]["accessed"] = datetime.datetime(
+            2011, 9, 3, 10, 10, 10
+        )
         return ok_response_factory()
 
     def test_panel(self):
@@ -460,7 +543,7 @@ class TestSimpleSession(_TestDebugtoolbarPanel):
                 "session_a",
             ],
         )
-        (resp_app2, resp_toolbar2) = self._makeAnother(resp_app)
+        (resp_app2, resp_toolbar2) = self._makeTwo(resp_app)
         self._check_rendered__panel(
             resp_toolbar2,
             is_configured=True,
@@ -482,7 +565,7 @@ class TestSimpleSession(_TestDebugtoolbarPanel):
                 "session_a",
             ],
         )
-        (resp_app2, resp_toolbar2) = self._makeAnother(resp_app, is_active=True)
+        (resp_app2, resp_toolbar2) = self._makeTwo(resp_app, is_active=True)
         self._check_rendered__panel(
             resp_toolbar2,
             is_configured=True,
@@ -494,6 +577,32 @@ class TestSimpleSession(_TestDebugtoolbarPanel):
         self.assertIn("<code>'bar'</code>", resp_toolbar2.text)
         self.assertIn("<code>'barbar'</code>", resp_toolbar2.text)
 
+    def test_panel_datetime(self):
+        (resp_app1, resp_toolbar1) = self._makeDatetime(resp_app=None, is_active=True)
+        self._check_rendered__panel(
+            resp_toolbar1,
+            is_configured=True,
+            sessions_accessed=[
+                "session_datetime",
+            ],
+        )
+        self.assertIn(
+            "<code>datetime.datetime(2011, 9, 3, 10, 10, 10)</code>", resp_toolbar1.text
+        )
+        (resp_app2, resp_toolbar2) = self._makeDatetime(
+            resp_app=resp_app1, is_active=True
+        )
+        self._check_rendered__panel(
+            resp_toolbar2,
+            is_configured=True,
+            sessions_accessed=[
+                "session_datetime",
+            ],
+        )
+        self.assertIn(
+            "<code>datetime.datetime(2011, 9, 3, 10, 10, 10)</code>", resp_toolbar2.text
+        )
+
 
 class TestSessionAlt(_TestDebugtoolbarPanel):
     """
@@ -502,13 +611,13 @@ class TestSessionAlt(_TestDebugtoolbarPanel):
     * "Session" data is accessed
     """
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         # touches the session
         request.session_multi["session_a"]["foo"] = "bar"
         request.session_multi["session_b"]["biz"] = "bang"
         return ok_response_factory()
 
-    def _session_view_two(self, context, request):
+    def _session_view_two(self, context, request: "Request"):
         # no session interaction
         return ok_response_factory()
 
@@ -547,7 +656,7 @@ class TestSessionAlt(_TestDebugtoolbarPanel):
                 "session_b",
             ],
         )
-        (resp_app2, resp_toolbar2) = self._makeAnother(resp_app)
+        (resp_app2, resp_toolbar2) = self._makeTwo(resp_app)
         self._check_rendered__panel(
             resp_toolbar2, is_configured=True, sessions_accessed=[]
         )
@@ -566,7 +675,7 @@ class TestSessionAlt(_TestDebugtoolbarPanel):
                 "session_b",
             ],
         )
-        (resp_app2, resp_toolbar2) = self._makeAnother(resp_app, is_active=True)
+        (resp_app2, resp_toolbar2) = self._makeTwo(resp_app, is_active=True)
         self._check_rendered__panel(
             resp_toolbar2, is_configured=True, sessions_accessed=[]
         )
@@ -585,7 +694,7 @@ class TestSortingErrorsSession(_TestDebugtoolbarPanel):
     to sort a float and a string under Python3.
     """
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         rand = random.random()
         request.session_multi["session_a"][rand] = True
         request.session_multi["session_a"]["foo"] = "bar"
@@ -613,7 +722,7 @@ class TestDiscriminatedSessions(_TestDebugtoolbarPanel):
         "session_c",  # fail
     ]
 
-    def _session_view(self, context, request):
+    def _session_view(self, context, request: "Request"):
         # touches the session
         # discriminated session: pass
         request.session_multi["session_a"]["foo"] = "bar"

--- a/tests/test_session_multi.py
+++ b/tests/test_session_multi.py
@@ -1,20 +1,17 @@
 # stdlib
 import unittest
 
-# pyramid
+# pypi
 from pyramid import testing
 from pyramid.threadlocal import get_current_request
 
-# package
+# local
 from pyramid_session_multi import new_session_multi
 from pyramid_session_multi import register_session_factory
 from pyramid_session_multi import SessionMultiManager
 from pyramid_session_multi import UnregisteredSession
-
-# local
-from ._utils import discriminator_True
 from ._utils import discriminator_False
-from ._utils import PY3
+from ._utils import discriminator_True
 from ._utils import session_factory_1
 from ._utils import session_factory_2
 from ._utils import session_factory_3
@@ -45,8 +42,6 @@ class Test_Session(unittest.TestCase):
         self.assertIsInstance(request.session_multi, SessionMultiManager)
         session_type_string = (
             "<class 'pyramid.session.BaseCookieSessionFactory.<locals>.CookieSession'>"
-            if PY3
-            else "<class 'pyramid.session.CookieSession'>"
         )
         self.assertEqual(
             str(type(request.session_multi["session_1"])), session_type_string

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
 	lint,
 	mypy,
-	py36,py37,py38,py39,py310,py311
+	py37,py38,py39,py310,py311,py312,py313
 
 [testenv]
 commands =


### PR DESCRIPTION
* improved typing and tests
* the default SignedCookieSessionFactory serializer switched from pickle to json; tests were expanded to include testing with custom serializers that can handle datetime objects.